### PR TITLE
Gemini support

### DIFF
--- a/Sources/CommonModules/Entiry/FunctionTool.swift
+++ b/Sources/CommonModules/Entiry/FunctionTool.swift
@@ -24,7 +24,7 @@ public enum FunctionToolType: String, Codable {
             self = .none
         case .chatGPT:
             self = .function
-        case .llama:
+        case .llamaOrGemini:
             self = .none
         }
     }
@@ -72,8 +72,8 @@ extension FunctionTool: Encodable {
             var container = encoder.container(keyedBy: ChatGPTCodingKeys.self)
             try container.encode(type, forKey: .type)
             try container.encode(function, forKey: .function)
-        case .llama:
-            // Llama API accepts JSON with the following structure.
+        case .llamaOrGemini:
+            // Llama API or Gemini API accepts JSON with the following structure.
             // ```json
             // [{
             //   { ...(function decralation)... }
@@ -102,9 +102,9 @@ extension FunctionTool: Decodable {
                 self.service = .claude
                 self.function = function
             } else {
-                self.service = .llama
+                self.service = .llamaOrGemini
                 self.function = .init(
-                    service: .llama,
+                    service: .llamaOrGemini,
                     name: function.name,
                     description: function.description,
                     inputSchema: function.inputSchema)

--- a/Sources/CommonModules/Entiry/Tool.swift
+++ b/Sources/CommonModules/Entiry/Tool.swift
@@ -99,7 +99,7 @@ extension Tool: Encodable {
             try container.encode(true, forKey: .strict)
             try container.encode(description, forKey: .description)
             try container.encode(inputSchema, forKey: .parameters)
-        case .llama:
+        case .llamaOrGemini:
             var container = encoder.container(keyedBy: LlamaCodingKeys.self)
             try container.encode(name, forKey: .name)
             try container.encode(description, forKey: .description)
@@ -118,8 +118,12 @@ extension Tool: Decodable {
             self.service = .claude
             self.inputSchema = inputSchema
         } else {
-            self.service = .chatGPT
             let chatGPTContainer = try decoder.container(keyedBy: ChatGPTCodingKeys.self)
+            if let _ = try? chatGPTContainer.decode(Bool.self, forKey: .strict) {
+                self.service = .chatGPT
+            } else {
+                self.service = .llamaOrGemini
+            }
             self.inputSchema = try chatGPTContainer.decode(InputSchema.self, forKey: .parameters)
         }
     }

--- a/Sources/CommonModules/FunctionCallingService.swift
+++ b/Sources/CommonModules/FunctionCallingService.swift
@@ -13,6 +13,6 @@ public enum FunctionCallingService: String, Codable {
     case claude
     /// [Chat GPT](https://chatgpt.com)
     case chatGPT
-    /// [Llama](https://www.llama-api.com)
-    case llama
+    /// [Llama](https://www.llama-api.com) and [Gemini](https://ai.google.dev/gemini-api) has the same structure
+    case llamaOrGemini
 }

--- a/Tests/SyntaxRendererTests/FunctionToolTests.swift
+++ b/Tests/SyntaxRendererTests/FunctionToolTests.swift
@@ -264,7 +264,7 @@ final class FunctionToolTests: XCTestCase {
     // MARK: Llama
 
     func testEncodingFunctionForLlama() throws {
-        let tool = FunctionTool(service: .llama, function: Self.getHTML(service: .llama))
+        let tool = FunctionTool(service: .llamaOrGemini, function: Self.getHTML(service: .llamaOrGemini))
         let jsonData = try FunctionCallingEncoder.encode(tool)
         if let dictionary = try JSONSerialization.jsonObject(with: jsonData, options: []) as? [String: Any] {
             // swiftlint:disable:next force_cast
@@ -290,8 +290,8 @@ final class FunctionToolTests: XCTestCase {
 
     func testEncodingFunctionsForLlama() throws {
         let tools = [
-            FunctionTool(service: .llama, function: Self.getHTML(service: .llama)),
-            FunctionTool(service: .llama, function: Self.timeOfDay(service: .llama))
+            FunctionTool(service: .llamaOrGemini, function: Self.getHTML(service: .llamaOrGemini)),
+            FunctionTool(service: .llamaOrGemini, function: Self.timeOfDay(service: .llamaOrGemini))
         ]
 
         let jsonData = try FunctionCallingEncoder.encode(tools)
@@ -342,14 +342,14 @@ final class FunctionToolTests: XCTestCase {
     }
 
     func testDecodingFunctionLlama() throws {
-        let tool = FunctionTool(service: .llama, function: Self.getHTML(service: .llama))
+        let tool = FunctionTool(service: .llamaOrGemini, function: Self.getHTML(service: .llamaOrGemini))
         let jsonData = try FunctionCallingEncoder.encode(tool)
         let result = try FunctionCallingDecoder.decode(FunctionTool.self, from: jsonData)
 
-        XCTAssertEqual(result.service, .llama)
+        XCTAssertEqual(result.service, .llamaOrGemini)
         XCTAssertEqual(result.type, .none)
         XCTAssertEqual(result.function.name, "getHTML")
-        XCTAssertEqual(result.function.service, .llama)
+        XCTAssertEqual(result.function.service, .llamaOrGemini)
         XCTAssertEqual(result.function.description, "This is description for `getHTML` method.")
         XCTAssertEqual(result.function.inputSchema.type, .object)
         XCTAssertEqual(result.function.inputSchema.properties?.count, 1)

--- a/Tests/SyntaxRendererTests/ToolTests.swift
+++ b/Tests/SyntaxRendererTests/ToolTests.swift
@@ -140,4 +140,46 @@ final class ToolTests: XCTestCase {
         XCTAssertEqual(urlString.nullable, false)
         XCTAssertEqual(result.inputSchema.requiredProperties, ["urlString"])
     }
+
+    func testEncodeForLlamaOrGemini() throws {
+        let tool = Self.getHTML(service: .llamaOrGemini)
+        let jsonData = try FunctionCallingEncoder.encode(tool)
+        if let dictionary = try JSONSerialization.jsonObject(with: jsonData, options: []) as? [String: Any] {
+            // swiftlint:disable:next force_cast
+            XCTAssertEqual(dictionary["name"] as! String, "getHTML")
+            // swiftlint:disable:next force_cast
+            XCTAssertEqual(dictionary["description"] as! String, "This is description for `getHTML` method.")
+
+            let parameters = try XCTUnwrap(dictionary["parameters"] as? [String: Any])
+            // swiftlint:disable:next force_cast
+            XCTAssertEqual(parameters["type"] as! String, "object")
+
+            let properties = try XCTUnwrap(parameters["properties"] as? [String: Any])
+            XCTAssertEqual(properties.keys.count, 1)
+            XCTAssertEqual(properties.keys.first, "urlString")
+
+            let requiredProperties = try XCTUnwrap(parameters["required"] as? [String])
+            XCTAssertEqual(requiredProperties.count, 1)
+            XCTAssertEqual(requiredProperties.first, "urlString")
+        } else {
+            XCTFail("JSON data should be selialized into dictionary")
+        }
+    }
+
+    func testDecodeForLlamaOrGemini() throws {
+        let tool = Self.getHTML(service: .llamaOrGemini)
+        let jsonData = try FunctionCallingEncoder.encode(tool)
+        let result = try FunctionCallingDecoder.decode(Tool.self, from: jsonData)
+
+        XCTAssertEqual(result.name, "getHTML")
+        XCTAssertEqual(result.service, .llamaOrGemini)
+        XCTAssertEqual(result.description, "This is description for `getHTML` method.")
+        XCTAssertEqual(result.inputSchema.type, .object)
+        XCTAssertEqual(result.inputSchema.properties?.count, 1)
+        let urlString = try XCTUnwrap(result.inputSchema.properties?["urlString"])
+        XCTAssertEqual(urlString.type, .string)
+        XCTAssertEqual(urlString.description, "This is description for `urlString` property")
+        XCTAssertEqual(urlString.nullable, false)
+        XCTAssertEqual(result.inputSchema.requiredProperties, ["urlString"])
+    }
 }


### PR DESCRIPTION
fix #3 

The Gemini API accepts input with the same structure as the Llama API. Therefore, this change adds a service case that supports both Llama and Gemini.

Also, some bugs in the code that decodes JSON structures supporting Llama (or Gemini) have been fixed and tests added.